### PR TITLE
fix 'replace' params

### DIFF
--- a/chapters/chapter_06_fp_techniques/03_currying.ts
+++ b/chapters/chapter_06_fp_techniques/03_currying.ts
@@ -44,7 +44,7 @@ namespace currying_demo_3 {
         return (a: T1) => (b: T2) => (c: T3) => fn(a, b, c);
     }
 
-    const replace = (s: string, f: string, r: string) => s.split(f).join(r);
+    const replace = (f: string, r: string, s: string) => s.split(f).join(r);
 
     const curriedReplace = curry3(replace);
 

--- a/chapters/chapter_06_fp_techniques/05_pipes.ts
+++ b/chapters/chapter_06_fp_techniques/05_pipes.ts
@@ -12,7 +12,7 @@ namespace pipes_demo_1 {
     const capitalize = (s: string) => s.toUpperCase();
     
     const replace = curry3(
-        (s: string, f: string, r: string) => s.split(f).join(r)
+        (f: string, r: string, s: string) => s.split(f).join(r)
     );
 
     const trimCapitalizeAndReplace = pipe(


### PR DESCRIPTION
The parameters for replace were out of order, resulting in an unexpected output. "s" is the param that gets called last, so moving the order corrects the issue.